### PR TITLE
fix: replace deprecated use of set-output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         id: get_latest_vsix_filename
         run: |
           latest_vsix=$(find . -type f -name "*.vsix" -printf "%T@ %p\n" | sort -n | tail -n 1 | cut -f2- -d" ")
-          echo "::set-output name=latest_vsix_filename::$latest_vsix"
+          run: echo "{latest_vsix_filename}={$latest_vsix}" >> $GITHUB_OUTPUT
 
       - name: Move to Release Branch
         run: |
@@ -106,7 +106,7 @@ jobs:
         id: version
         run: |
           latest_version=$(tail -n 1 sorted_vsix_files.txt | cut -d'-' -f 3 | cut -d'.' -f 1,2)
-          echo "::set-output name=version::$latest_version"
+          run: echo "{version}={$latest_version}" >> $GITHUB_OUTPUT
 
       - name: Commit and Push Changes
         run: |


### PR DESCRIPTION
Replaced deprecated use of set-output following: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/