### PR TITLE
feat: add configurable options

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,16 @@
         "translationFileWatcher.localesAbsolutePath": {
           "type": "string",
           "description": "Absolute path to the locales directory of your project (the parent directory containing your *.po and *.json files)."
+        },
+        "translationFileWatcher.defaultFileLockOnBoot": {
+          "type": "boolean",
+          "default": false,
+          "description": "Choose whether you would like the file watcher to be enabled at boot time. Or whether you would rather have to enable the file watcher manually each time."
+        },
+        "translationFileWatcher.generatePo": {
+          "type": "boolean",
+          "default": true,
+          "description": "Since it's possible that for your use case, you only need json files, it's possible to disable the po file generation using this setting."
         }
       }
     }


### PR DESCRIPTION
It's now completely up to the user of the extension whether he wants po files to be generated or not. Also it's now possible to enable the master file lock by default on boot. And finally, it's now possible to manually trigger json file generation by clicking on the CODE taskbar item.