### PR TITLE
fix: code gen button

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -466,7 +466,7 @@ export async function activate(context: vscode.ExtensionContext) {
       );
 
     codeFileWatcherStatusBarItem.command =
-      'extension.codeFileWatcherStatusBarItemClickedCommand';
+      'extension.codeFileWatcherStatusBarItemClicked';
 
     context.subscriptions.push(
       poFileWatcherStatusBarItemClickedCommand,


### PR DESCRIPTION
Fix issues where pressing code gen button in taskbar threw an error.