### PR TITLE
ci(release): fix standard version config

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,9 +1,4 @@
 {
-  "preMajor": true,
-  "scripts": {
-    "postchangelog": "./gh-actions-scripts/post-changelog-actions.sh"
-  },
-  "tagPrefix": "",
   "types": [
     {
       "type": "feat",


### PR DESCRIPTION
The old config pointed to a non existent script, preventing releases.