### PR TITLE
fix: update paths to be relative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "translation-file-watcher",
-  "version": "1.7.2-alpha.0",
+  "version": "1.7.2-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "translation-file-watcher",
-      "version": "1.7.2-alpha.0",
+      "version": "1.7.2-alpha.1",
       "dependencies": {
         "i18next-conv": "^14.0.0",
         "i18next-scanner": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/qvotaxon/translation-file-watcher"
   },
   "version": "1.7.2-alpha.1",
-  "configurationVersion": "0.0.1",
+  "configurationVersion": "0.0.2",
   "engines": {
     "vscode": "^1.86.0"
   },
@@ -30,13 +30,13 @@
             "default": "i18next-scanner.config.js",
             "description": "Path relative from the root of the workspace to the i18n-next scanner configuration file (i18next-scanner.config.js)."
           },
-          "translationFileWatcher.filePaths.packageJsonAbsolutePath": {
+          "translationFileWatcher.filePaths.packageJsonRelativePath": {
             "type": "string",
-            "description": "Absolute path to the project's package.json file. This location serves as the root for all other commands and configurations."
+            "description": "Relative path to the project's package.json file. This location serves as the root for all other commands and configurations."
           },
-          "translationFileWatcher.filePaths.localesAbsolutePath": {
+          "translationFileWatcher.filePaths.localesRelativePath": {
             "type": "string",
-            "description": "Absolute path to the project's localization directory (the parent directory containing *.po and *.json files)."
+            "description": "Relative path to the project's localization directory (the parent directory containing *.po and *.json files)."
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/qvotaxon/translation-file-watcher"
   },
-  "version": "1.7.2-alpha.0",
+  "version": "1.7.2-alpha.1",
   "configurationVersion": "0.0.1",
   "engines": {
     "vscode": "^1.86.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,10 @@ import {
   handlePOFileChange,
   handleCodeFileChange,
 } from './lib/fileHandling';
-import { findPackageJson, getLastThreeDirectories } from './lib/fileManagement';
+import {
+  getPackageJsonAbsolutePath,
+  getLastThreeDirectories,
+} from './lib/fileManagement';
 import {
   notifyRequiredSettings,
   initializeStatusBarItems,
@@ -56,7 +59,7 @@ export async function activate(context: vscode.ExtensionContext) {
     'Activated Translation File Watcher Extension.'
   );
 
-  const packageJsonPath = await findPackageJson();
+  const packageJsonPath = await getPackageJsonAbsolutePath();
   if (packageJsonPath) {
     vscode.window.setStatusBarMessage(
       `TFW: ${getLastThreeDirectories(
@@ -91,8 +94,14 @@ export async function activate(context: vscode.ExtensionContext) {
   /**
    * TODO> Move to seperate function
    */
-  const localesAbsolutePath = getConfig().get<string>('localesAbsolutePath');
-  if (localesAbsolutePath) {
+  let localesRelativePath = getConfig().get<string>(
+    'filePaths.localesRelativePath'
+  );
+  if (localesRelativePath) {
+    const localesAbsolutePath = `${
+      vscode.workspace.workspaceFolders![0].uri.fsPath
+    }\\${localesRelativePath}`;
+
     let poFileWatcherStatusBarItemClickedCommand =
       vscode.commands.registerCommand(
         'extension.poFileWatcherStatusBarItemClicked',

--- a/src/lib/backgroundProcessExecution.ts
+++ b/src/lib/backgroundProcessExecution.ts
@@ -1,13 +1,13 @@
 import { spawn } from 'child_process';
 import { CallbackOnMatch } from './Types';
-import { findPackageJson } from './fileManagement';
+import { getPackageJsonAbsolutePath } from './fileManagement';
 import path from 'path';
 
 let projectRootPath: string | undefined = undefined;
 
 async function getProjectRootPath(): Promise<string> {
   if (!projectRootPath) {
-    const packageJsonPath = await findPackageJson();
+    const packageJsonPath = await getPackageJsonAbsolutePath();
 
     projectRootPath = path.dirname(packageJsonPath!);
   }

--- a/src/lib/fileManagement.ts
+++ b/src/lib/fileManagement.ts
@@ -80,12 +80,17 @@ export function extractParts(filePath: string): {
   return { jsonOutputPath, poOutputPath, locale };
 }
 
-export async function findPackageJson(): Promise<string | undefined> {
-  const packageJsonAbsolutePath = getConfig().get<string>(
-    'packageJsonAbsolutePath'
+export async function getPackageJsonAbsolutePath(): Promise<
+  string | undefined
+> {
+  const packageJsonRelativePath = getConfig().get<string>(
+    'filePaths.packageJsonRelativePath'
   );
+  const packageJsonAbsolutePath = `${
+    vscode.workspace.workspaceFolders![0].uri.fsPath
+  }\\${packageJsonRelativePath}`;
 
-  if (packageJsonAbsolutePath) {
+  if (packageJsonRelativePath) {
     if (!fs.existsSync(packageJsonAbsolutePath)) {
       return undefined;
     }


### PR DESCRIPTION
Make the required configurable paths relative so it's now possible to move your project around, without having to reconfigure the extension.