### PR TITLE
Feat/make file locks file specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/qvotaxon/translation-file-watcher"
   },
   "version": "1.8.1",
-  "configurationVersion": "0.0.2",
+  "configurationVersion": "0.0.3",
   "engines": {
     "vscode": "^1.86.0"
   },

--- a/src/lib/file-lock-manager.ts
+++ b/src/lib/file-lock-manager.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { OutputChannelLogger } from './OutputChannelLogger';
 
 let masterLock = false;
-let poFilesLocks = 0;
+let poFilesLocks = new Map<string, number>();
 
 export function setMasterLock(value: boolean): void {
   masterLock = value;
@@ -15,27 +15,63 @@ export function setMasterLock(value: boolean): void {
 }
 
 //TODO: Rename to FileWatchLock? Since it blocks the file watchers from reacting to changes. Instead of not being able to write to the files.
-export function addPoFilesLock(): void {
-  poFilesLocks++;
+export function addPoFilesLock(locale: string): void {
+  let currentCount = poFilesLocks.get(locale);
+  if (currentCount) {
+    poFilesLocks.set(locale, ++currentCount);
+  } else {
+    poFilesLocks.set(locale, 1);
+  }
   OutputChannelLogger.appendLine(
-    `Added 1. Po File Locks Active: ${poFilesLocks}`
+    `Added 1. Po File Locks Active for locale ${locale}: ${poFilesLocks.get(
+      locale
+    )}`
   );
 }
 
-export function removePoFileLock(): void {
-  poFilesLocks--;
-  OutputChannelLogger.appendLine(
-    `Removed 1. Po File Locks Active: ${poFilesLocks}`
-  );
+export function removePoFileLock(locale: string): void {
+  let currentCount = poFilesLocks.get(locale);
+  if (currentCount) {
+    poFilesLocks.set(locale, --currentCount);
+    OutputChannelLogger.appendLine(
+      `Removed 1. Po File Locks Active for locale ${locale}: ${poFilesLocks.get(
+        locale
+      )}`
+    );
+  } else {
+    OutputChannelLogger.appendLine(`Po files not locked for locale: ${locale}`);
+  }
+}
+
+export function isPoFileLocked(locale: string): boolean {
+  OutputChannelLogger.appendLine(`Po files locked for locale: ${locale}`);
+
+  let localeLock = poFilesLocks.get(locale);
+
+  return localeLock !== undefined && localeLock > 0;
 }
 
 export function arePoFilesLocked(): boolean {
+  let poFileLockExists = false;
+
+  poFilesLocks.forEach((poFileLock) => {
+    if (poFileLock > 0) {
+      poFileLockExists = true;
+      return;
+    }
+  });
+
   OutputChannelLogger.appendLine(
-    `Po files locked: ${masterLock || poFilesLocks > 0}`
+    `Po files locked: ${masterLock || poFileLockExists}`
   );
-  return masterLock || poFilesLocks > 0;
+
+  return masterLock || poFileLockExists;
 }
 
 export function isMasterLockEnabled(): boolean {
+  OutputChannelLogger.appendLine(
+    `Master lock is ${masterLock ? 'enabled' : 'disabled'}`
+  );
+
   return masterLock;
 }

--- a/src/lib/fileHandling.ts
+++ b/src/lib/fileHandling.ts
@@ -29,20 +29,13 @@ export function checkMergeStatus(): boolean {
 }
 
 export function sortJsonFile(filePath: string): void {
-  // Read the JSON data from the file
   const jsonData = fs.readFileSync(filePath, 'utf-8');
   const jsonObject: JsonObject = JSON.parse(jsonData);
-
-  // Sort the JSON object
   const sortedObject = sortJson(jsonObject);
-
-  // Convert the sorted JSON object to a string with indentation of 4 spaces and desired line endings
   let jsonString = JSON.stringify(sortedObject, null, 4);
 
-  // Add a trailing newline
   jsonString += '\n';
 
-  // Write the modified JSON string back to the file
   fs.writeFileSync(filePath, jsonString, 'utf-8');
 }
 
@@ -229,56 +222,25 @@ export async function handleJsonFileChange(
   }
 }
 
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//
-
 let previousFileContents: string[] = [];
 let currentFileContents: string[] = [];
 
-// Function to handle file changes
 function updateCurrentFileContents(fsPath: string) {
-  // Read the current content of the file
   const fileContent = fs.readFileSync(fsPath, { encoding: 'utf8' });
-  // fs.readFile(fsPath, 'utf8', (err, fileContent) => {
-  //   if (err) {
-  //     console.error(err);
-  //     return;
-  //   }
-
   currentFileContents[fsPath as keyof object] = fileContent;
-
-  // });
 }
 
 function storeFileState(fsPath: string) {
-  // Get the previous content of the file
   const previousData = previousFileContents[fsPath as keyof object] || '';
 
-  // Compare the current content with the previous content
   if (currentFileContents[fsPath as keyof object] !== previousData) {
-    // Content has changed
     OutputChannelLogger.appendLine(`File contents of ${fsPath} changed.`);
 
-    // Update the previous content with the current content
     previousFileContents[fsPath as keyof object] =
       currentFileContents[fsPath as keyof object];
   }
 }
 
-// Function to extract translation keys from the changed lines
 function extractTranslationKeys(lines: string[]) {
   const translationKeys: string[] = [];
   const keyRegex = /(?:I18nKey|t)\(\s*['"`](.*?)['"`]\s*\)/g;
@@ -294,13 +256,11 @@ function extractTranslationKeys(lines: string[]) {
 }
 
 function getChangedLines(currentData: string, previousData: string): string[] {
-  // Split the content into lines
   const currentLines = currentData.split('\n');
   const previousLines = previousData?.split('\n') ?? [];
 
   const changedLines = [];
 
-  // Create maps of trimmed lines for efficient lookup
   const currentLineSet = new Set(currentLines.map((line) => line.trim()));
   const previousLineSet = new Set(previousLines.map((line) => line.trim()));
 
@@ -308,7 +268,6 @@ function getChangedLines(currentData: string, previousData: string): string[] {
   for (let i = 0; i < currentLines.length; i++) {
     const currentLine = currentLines[i].trim();
 
-    // If the line is not in the previous version, it's an added line
     if (!previousLineSet.has(currentLine)) {
       changedLines.push(currentLines[i]);
     }
@@ -318,7 +277,6 @@ function getChangedLines(currentData: string, previousData: string): string[] {
   for (let i = 0; i < previousLines.length; i++) {
     const previousLine = previousLines[i].trim();
 
-    // If the line is not in the current version, it's a removed line
     if (!currentLineSet.has(previousLine)) {
       changedLines.push(previousLines[i]);
     }
@@ -328,14 +286,12 @@ function getChangedLines(currentData: string, previousData: string): string[] {
 }
 
 function fileChangeContainsTranslationKeys(fsPath: string): boolean {
-  // Extract translation keys from the changed lines
   const changedLines = getChangedLines(
     currentFileContents[fsPath as keyof object],
     previousFileContents[fsPath as keyof object]
   );
   const translationKeys = extractTranslationKeys(changedLines);
 
-  // Output the found translation keys
   console.log('Changed lines:');
   console.log(changedLines);
   console.log('Translation keys:');
@@ -374,7 +330,6 @@ export async function handleCodeFileChange(
 
   updateCurrentFileContents(fsPath!);
 
-  // Compare the current content with the previous content
   const fileChangeOccurred =
     currentFileContents[fsPath as keyof object] !==
       previousFileContents[fsPath as keyof object] || '';
@@ -434,10 +389,8 @@ export function processPOFiles(
     const filePath = path.join(directory, file);
     const stat = fs.statSync(filePath);
     if (stat.isDirectory()) {
-      // Recursively search subdirectories
       processPOFiles(filePath, triggeredByFileWatcher, callback);
     } else if (file.endsWith('.po')) {
-      // Call the callback function for *.po files
       callback(filePath, triggeredByFileWatcher);
     }
   });
@@ -452,10 +405,8 @@ export function processJSONFiles(
     const filePath = path.join(directory, file);
     const stat = fs.statSync(filePath);
     if (stat.isDirectory()) {
-      // Recursively search subdirectories
       processJSONFiles(filePath, triggeredByFileWatcher, callback);
     } else if (file.endsWith('.json')) {
-      // Call the callback function for *.json files
       callback(filePath, triggeredByFileWatcher);
     }
   });

--- a/src/lib/fileHandling.ts
+++ b/src/lib/fileHandling.ts
@@ -293,23 +293,6 @@ function extractTranslationKeys(lines: string[]) {
   return translationKeys;
 }
 
-// Function to extract changed lines from the file
-// function getChangedLines(currentData: string, previousData: string): string[] {
-//   // Split the content into lines
-//   const currentLines = currentData.split('\n');
-//   const previousLines = previousData?.split('\n') ?? [];
-
-//   // Find the changed lines
-//   const changedLines = [];
-//   for (let i = 0; i < currentLines.length; i++) {
-//     if (currentLines[i] !== previousLines[i]) {
-//       changedLines.push(currentLines[i]);
-//     }
-//   }
-
-//   return changedLines;
-// }
-
 function getChangedLines(currentData: string, previousData: string): string[] {
   // Split the content into lines
   const currentLines = currentData.split('\n');
@@ -343,52 +326,6 @@ function getChangedLines(currentData: string, previousData: string): string[] {
 
   return changedLines;
 }
-
-// Function to extract changed lines from the file
-// function getChangedLines(currentData: string, previousData: string): string[] {
-//   // Split the content into lines
-//   const currentLines = currentData.split('\n');
-//   const previousLines = previousData?.split('\n') ?? [];
-
-//   // Compare line counts
-//   if (currentLines.length !== previousLines.length) {
-//     // Line counts are different, but text content might be the same
-//     const minLength = Math.min(currentLines.length, previousLines.length);
-//     let commonLines = 0;
-
-//     // Find the number of common lines at the beginning
-//     for (let i = 0; i < minLength; i++) {
-//       if (currentLines[i] === previousLines[i]) {
-//         commonLines++;
-//       } else {
-//         break;
-//       }
-//     }
-
-//     // Calculate the number of lines added or removed
-//     const linesAdded = currentLines.length - commonLines;
-//     const linesRemoved = previousLines.length - commonLines;
-
-//     // If lines are added at the top
-//     if (linesAdded > linesRemoved) {
-//       return currentLines.slice(0, linesAdded);
-//     }
-//     // If lines are removed from the top
-//     else if (linesRemoved > linesAdded) {
-//       return previousLines.slice(0, linesRemoved);
-//     }
-//   }
-
-//   // Find the changed lines
-//   const changedLines = [];
-//   for (let i = 0; i < currentLines.length; i++) {
-//     if (currentLines[i] !== previousLines[i]) {
-//       changedLines.push(currentLines[i]);
-//     }
-//   }
-
-//   return changedLines;
-// }
 
 function fileChangeContainsTranslationKeys(fsPath: string): boolean {
   // Extract translation keys from the changed lines


### PR DESCRIPTION
Each *.po / *.json file will now have its own file watching process to improve simultaneous file change handling. 

The tasks executed by the file watchers are now debounced, so multiple saves in quick succession don't impact performance. Additionally, if any task is already running it will be cancelled when a debounced task is executed, because only the output of the last will count anyway. This also prevents multiple file scanners to start when Save All Files is used.

Next to this, the file locks on the *.po files are now file specific, making it possible to edit multiple *.po file simultaneously or in quick succession.

Code file changes are now checked for translation keys in order to determine whether to run the scanner logic or not. This will improve performance since saves will no longer cause the code scanner to execute. The logic takes into consideration changes in line positions. Meaning that adding new code without translation keys, above existing code with translation keys, will not cause the translation key extraction to execute. Of course, this will occur when the newly added code does contain translation keys.

The extension now logs messages to the output window. You can toggle verbose logging in the settings.