### PR TITLE
perf: initialize file cache on startup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,16 +137,19 @@ export async function activate(context: vscode.ExtensionContext) {
     );
   }
   //TODO: use relativeLocalesPath to read po files from. Same for tsx ts files.
+  await fileChangeHandler.initializeInitialFileContentsAsync(
+    '**/{apps,libs}/**/*.{tsx,ts}'
+  );
 
   const poFileWatchers = fileWatcherCreator.createFileWatcherForEachFileInGlob(
-    '**/locales/**/*.po',
+    `${localesRelativePath}/**/locales/**/*.po`,
     fileChangeHandler.handlePOFileChange,
     fileLockManager.isMasterLockEnabled,
     fileLockManager.arePoFilesLocked
   );
   const jsonFileWatchers =
     fileWatcherCreator.createFileWatcherForEachFileInGlob(
-      '**/locales/**/*.json',
+      `${localesRelativePath}/**/locales/**/*.json`,
       fileChangeHandler.handleJsonFileChange,
       fileLockManager.isMasterLockEnabled
     );


### PR DESCRIPTION
The translation key cache will now be initialized on startup. Ensuring saves will always only trigger the file generation process when the file changes contain translation keys. Previously, this would only happen after the first safe occurred.