### PR TITLE
chore: remove void from globalState.update call

### DIFF
--- a/src/lib/configurationManager.ts
+++ b/src/lib/configurationManager.ts
@@ -47,7 +47,7 @@ export class ConfigurationManager {
     );
 
     if (currentVersion !== lastVersion) {
-      void context.globalState.update(
+      context.globalState.update(
         'TranslationFileWatcherExtensionVersion',
         currentVersion
       );


### PR DESCRIPTION
Remove the unnecessary void operator from the globalState.update
call within the ConfigurationManager.