### PR TITLE
fix: disable formality for en target language

### DIFF
--- a/src/lib/translationService.ts
+++ b/src/lib/translationService.ts
@@ -116,11 +116,7 @@ class TranslationService {
           text: string,
           targetLanguage: string
         ): Promise<string> => {
-          if (targetLanguage === 'en') {
-            targetLanguage = 'en-US';
-          }
-
-          const formality = configurationManager.getValue<string>(
+          let formality = configurationManager.getValue<string>(
             'translations.deeplFormality',
             'default'
           );
@@ -131,6 +127,11 @@ class TranslationService {
             'translations.deeplPreserveFormatting',
             false
           );
+
+          if (targetLanguage === 'en') {
+            targetLanguage = 'en-US';
+            formality = 'default';
+          }
 
           const result = await this.getTranslator().translateText(
             text,


### PR DESCRIPTION
Set the DeepL formality to 'default' when translating to
English (en-US). Because formality is not a valid property for target language en.